### PR TITLE
Refractor, bug fix and unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,21 @@ yarn add @allanchain/gridsome-plugin-pwa register-service-worker
 
 - **manifestOptions**
 
-  - Default: `{}`
+  - Default: 
+    - `{}` if `InjectManifest`
+    - if `GenerateSW`
+
+      you can override `/assets\/icons/` if provide `exclude` yourself, but cannot override first two because thay are to prevent error.
+
+      ```js
+      {
+        exclude: [
+          /styles(\.\w{8})?\.js$/,
+          /manifest\/client.json$/,
+          /assets\/icons/
+        ]
+      }
+      ```
 
     The object will be used to generate the `manifest.json`
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ yarn add @allanchain/gridsome-plugin-pwa register-service-worker
 
     The path of app’s manifest. If the path is an URL, the plugin won't generate a manifest.json in the dist directory during the build.
 
+Options below are different to `cli-plugin-pwa`
+
+---
+
 - **manifestOptions**
 
   - Default: 
@@ -116,10 +120,6 @@ yarn add @allanchain/gridsome-plugin-pwa register-service-worker
       - start_url: `'.'`
       - display: `'standalone'`
       - theme_color: `themeColor`
-
-Options below are different to `cli-plugin-pwa`
-
----
 
 - **icon**
 

--- a/__tests__/basic.build.e2e.js
+++ b/__tests__/basic.build.e2e.js
@@ -22,7 +22,6 @@ describe('manifest.json', () => {
     manifest = JSON.parse(fs.readFileSync(manifestFilePath))
   })
   it('contains configured fields', () => {
-    expect(manifest.name).toBe('Awesome Gridsome')
     expect(manifest.short_name).toBe('Gridsome')
     expect(manifest.start_url).toBe('/')
     expect(manifest.icons).toBeInstanceOf(Array)
@@ -34,6 +33,7 @@ describe('manifest.json', () => {
     })
   })
   it('honors default options', () => {
+    expect(manifest.name).toBe('Awesome Gridsome')
     expect(manifest.background_color).toBe('#000000')
     expect(manifest.theme_color).toBe('#00a672')
   })

--- a/__tests__/basic.build.e2e.js
+++ b/__tests__/basic.build.e2e.js
@@ -59,10 +59,15 @@ describe('sevice worker', () => {
   it('uses correct cache id', () => {
     expect(swContent).toMatch('setCacheNameDetails({prefix:"awesome-pwa"})')
   })
-  it('ignores correctly', () => {
+  it('does essential ignore', () => {
     expect(swContent).not.toMatch('client.json')
-    expect(swContent).not.toMatch('manifest.json')
     expect(swContent).not.toMatch('js/style')
+  })
+  it('does configured ignore', () => {
+    expect(swContent).not.toMatch('manifest.json')
+  })
+  it('does not ignore default if configured', () => {
+    expect(swContent).toMatch('assets/icons')
   })
   it('includes prefetch assets', () => {
     expect(swContent).toMatch('/assets/js/app')

--- a/__tests__/basic.build.e2e.js
+++ b/__tests__/basic.build.e2e.js
@@ -16,11 +16,12 @@ beforeAll(async () => {
 
 describe('manifest.json', () => {
   const manifestFilePath = dist('manifest.json')
+  let manifest
   it('exists', () => {
     expect(fs.existsSync(manifestFilePath)).toBeTruthy()
+    manifest = JSON.parse(fs.readFileSync(manifestFilePath))
   })
   it('contains configured fields', () => {
-    const manifest = JSON.parse(fs.readFileSync(manifestFilePath))
     expect(manifest.name).toBe('Awesome Gridsome')
     expect(manifest.short_name).toBe('Gridsome')
     expect(manifest.start_url).toBe('/')
@@ -31,6 +32,10 @@ describe('manifest.json', () => {
       sizes: '192x192',
       purpose: 'any'
     })
+  })
+  it('honors default options', () => {
+    expect(manifest.background_color).toBe('#000000')
+    expect(manifest.theme_color).toBe('#00a672')
   })
 })
 

--- a/__tests__/manifest.unit.js
+++ b/__tests__/manifest.unit.js
@@ -1,0 +1,21 @@
+const generateManifest = require('../lib/generateManifest')
+const { defaultOptions } = require('../gridsome.server')
+const defaultsDeep = require('lodash/defaultsDeep')
+
+const manifest = userOptions => generateManifest({
+  name: 'Awesome Gridsome',
+  ...defaultsDeep(userOptions, defaultOptions())
+})
+
+describe('Generate Manifest', () => {
+  it('works with zero config', () => {
+    expect(manifest({}).name).toBe('Awesome Gridsome')
+  })
+  it('does no have double slashes', () => {
+    expect(JSON.stringify(manifest({}))).not.toMatch('//')
+  })
+  it('gets correct icon type', () => {
+    expect(manifest({ icon: 'src/favicon.test.ico' }).icons[0].type)
+      .toBe('image/ico')
+  })
+})

--- a/__tests__/workbox.unit.js
+++ b/__tests__/workbox.unit.js
@@ -1,0 +1,37 @@
+const generateWorkboxConfig = require('../lib/generateWorkboxConfig')
+const { defaultOptions } = require('../gridsome.server')
+const defaultsDeep = require('lodash/defaultsDeep')
+
+const workbox = userOptions => {
+  const options = defaultsDeep(userOptions, defaultOptions())
+  return generateWorkboxConfig(
+    'Awesome Gridsome',
+    options.workboxPluginMode,
+    options.workboxOptions
+  )
+}
+
+describe('Generate Workbox Config', () => {
+  it('works with zero config', () => {
+    const config = workbox({})
+    expect(config.cacheId).toBe('Awesome Gridsome')
+    expect(config.exclude.length).toBe(3)
+  })
+  it('throws error on unknown mode', () => {
+    expect(() => workbox({ workboxPluginMode: 'InhectManidfet' }))
+      .toThrow('is not a supported')
+  })
+  it('takes config', () => {
+    expect(workbox({ workboxOptions: { skipWaiting: true } }).skipWaiting)
+      .toBeTruthy()
+  })
+  it('should be able to use InjectManifest', () => {
+    const config = workbox({
+      workboxPluginMode: 'InjectManifest',
+      workboxOptions: {
+        swSrc: 'src/sw.js'
+      }
+    })
+    expect(config).toEqual({ swSrc: 'src/sw.js' })
+  })
+})

--- a/examples/basic/gridsome.config.js
+++ b/examples/basic/gridsome.config.js
@@ -15,7 +15,6 @@ module.exports = {
           short_name: 'Gridsome',
           description: 'Gridsome is awesome!',
           display: 'standalone',
-          background_color: '#ffffff',
           gcm_sender_id: undefined,
           start_url: '/',
           categories: ['education'],

--- a/examples/basic/gridsome.config.js
+++ b/examples/basic/gridsome.config.js
@@ -5,12 +5,11 @@
 // To restart press CTRL + C in terminal and run `gridsome develop`
 
 module.exports = {
-  siteName: 'Gridsome',
+  siteName: 'Awesome Gridsome',
   plugins: [
     {
       use: '@allanchain/gridsome-plugin-pwa',
       options: {
-        name: 'Awesome Gridsome',
         manifestOptions: {
           short_name: 'Gridsome',
           description: 'Gridsome is awesome!',

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -48,9 +48,7 @@ Plugin.defaultOptions = () => ({
   maskableIcon: false,
   msTileColor: '#00a672',
   workboxPluginMode: 'GenerateSW',
-  workboxOptions: {
-    skipWaiting: true
-  }
+  workboxOptions: {}
 })
 
 module.exports = Plugin

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -7,7 +7,7 @@ function Plugin (api, options) {
 
     webpackConfig
       .plugin('pwa-manifest')
-      .use(ManifestPlugin, [options])
+      .use(ManifestPlugin, [{ name: api.config.siteName, ...options }])
 
     // generate /service-worker.js in production mode
     if (isProd) {
@@ -55,7 +55,6 @@ function Plugin (api, options) {
 }
 
 Plugin.defaultOptions = () => ({
-  name: 'Gridsome',
   appleMobileWebAppStatusBarStyle: 'default',
   appleMobileWebAppCapable: 'no',
   manifestPath: 'manifest.json',

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -24,7 +24,10 @@ function Plugin (api, options) {
       const essentialExclude = [
         // https://github.com/gridsome/gridsome/blob/2538985/gridsome/lib/webpack/utils.js#L5
         /styles(\.\w{8})?\.js$/,
-        /manifest\/client.json$/,
+        /manifest\/client.json$/
+      ]
+
+      const defaultExclude = [
         /assets\/icons/
       ]
 
@@ -36,7 +39,7 @@ function Plugin (api, options) {
 
       workBoxConfig.exclude = workBoxConfig.exclude
         ? essentialExclude.concat(workBoxConfig.exclude)
-        : essentialExclude
+        : essentialExclude.concat(defaultExclude)
 
       webpackConfig
         .plugin('workbox')

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -1,10 +1,8 @@
-const ManifestPlugin = require('./lib/manifestPlugin')
-const createNoopServiceWorkerMiddleware = require('./lib/noopServiceWorkerMiddleware')
-
 function Plugin (api, options) {
   api.chainWebpack((webpackConfig, { isServer, isProd }) => {
     if (isServer) return
 
+    const ManifestPlugin = require('./lib/manifestPlugin')
     webpackConfig
       .plugin('pwa-manifest')
       .use(ManifestPlugin, [{ name: api.config.siteName, ...options }])
@@ -23,7 +21,7 @@ function Plugin (api, options) {
   })
 
   api.configureServer(app => {
-    app.use(createNoopServiceWorkerMiddleware())
+    app.use(require('./lib/noopServiceWorkerMiddleware')())
   })
 
   api.setClientOptions({

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -11,39 +11,14 @@ function Plugin (api, options) {
 
     // generate /service-worker.js in production mode
     if (isProd) {
-      const workboxPluginMode = options.workboxPluginMode
       const workboxWebpackModule = require('workbox-webpack-plugin')
-
-      if (!(workboxPluginMode in workboxWebpackModule)) {
-        throw new Error(
-          `${workboxPluginMode} is not a supported Workbox webpack plugin mode. ` +
-          `Valid modes are: ${Object.keys(workboxWebpackModule).join(', ')}`
-        )
-      }
-
-      const essentialExclude = [
-        // https://github.com/gridsome/gridsome/blob/2538985/gridsome/lib/webpack/utils.js#L5
-        /styles(\.\w{8})?\.js$/,
-        /manifest\/client.json$/
-      ]
-
-      const defaultExclude = [
-        /assets\/icons/
-      ]
-
-      const defaultGenerateSWOptions = workboxPluginMode === 'GenerateSW' ? {
-        cacheId: api.config.siteName
-      } : {}
-
-      const workBoxConfig = Object.assign(defaultGenerateSWOptions, options.workboxOptions)
-
-      workBoxConfig.exclude = workBoxConfig.exclude
-        ? essentialExclude.concat(workBoxConfig.exclude)
-        : essentialExclude.concat(defaultExclude)
-
+      const generateWorkboxConfig = require('./lib/generateWorkboxConfig')
       webpackConfig
         .plugin('workbox')
-        .use(workboxWebpackModule[workboxPluginMode], [workBoxConfig])
+        .use(
+          workboxWebpackModule[options.workboxPluginMode],
+          [generateWorkboxConfig(api.config.siteName, options)]
+        )
     }
   })
 

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -15,7 +15,11 @@ function Plugin (api, options) {
         .plugin('workbox')
         .use(
           workboxWebpackModule[options.workboxPluginMode],
-          [generateWorkboxConfig(api.config.siteName, options)]
+          [generateWorkboxConfig(
+            api.config.siteName,
+            options.workboxPluginMode,
+            options.workboxOptions
+          )]
         )
     }
   })

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -60,7 +60,11 @@ Plugin.defaultOptions = () => ({
   appleMobileWebAppCapable: 'no',
   manifestPath: 'manifest.json',
   themeColor: '#00a672',
-  manifestOptions: {},
+  manifestOptions: {
+    start_url: '.',
+    display: 'standalone',
+    background_color: '#000000'
+  },
   icon: 'src/favicon.png',
   maskableIcon: false,
   msTileColor: '#00a672',

--- a/lib/generateManifest.js
+++ b/lib/generateManifest.js
@@ -16,9 +16,6 @@ module.exports = options => {
   }))
 
   const defaultManifest = {
-    start_url: '.',
-    display: 'standalone',
-    background_color: '#000000',
     icons,
     name: options.name,
     short_name: options.name,

--- a/lib/generateManifest.js
+++ b/lib/generateManifest.js
@@ -1,0 +1,28 @@
+const rename = require('rename')
+
+module.exports = options => {
+  const iconsDir = 'assets/icons/'
+  const iconName = options.icon.split('/').slice(-1)[0]
+  const type = 'image/' + iconName.split('.').slice(-1)[0]
+
+  // Generate all size images from options.icon
+  const allSizes = [512, 384, 192, 180, 152, 144, 128, 120, 96, 72, 48, 16]
+
+  const icons = allSizes.map((size) => ({
+    src: iconsDir + rename(iconName, { suffix: `-${size}x${size}` }),
+    type,
+    sizes: `${size}x${size}`,
+    purpose: options.maskableIcon ? 'maskable any' : 'any'
+  }))
+
+  const defaultManifest = {
+    start_url: '.',
+    display: 'standalone',
+    background_color: '#000000',
+    icons,
+    name: options.name,
+    short_name: options.name,
+    theme_color: options.themeColor
+  }
+  return Object.assign(defaultManifest, options.manifestOptions)
+}

--- a/lib/generateWorkboxConfig.js
+++ b/lib/generateWorkboxConfig.js
@@ -1,0 +1,34 @@
+const workboxModes = ['GenerateSW', 'InjectManifest']
+
+// https://github.com/gridsome/gridsome/blob/2538985/gridsome/lib/webpack/utils.js#L5
+const essentialExclude = [
+  /styles(\.\w{8})?\.js$/,
+  /manifest\/client.json$/
+]
+
+const defaultExclude = [
+  /assets\/icons/
+]
+
+module.exports = (siteName, options) => {
+  const workboxPluginMode = options.workboxPluginMode
+
+  if (!workboxModes.includes(workboxPluginMode)) {
+    throw new Error(
+      `${workboxPluginMode} is not a supported Workbox webpack plugin mode. ` +
+      `Valid modes are: ${workboxModes}`
+    )
+  }
+
+  const defaultGenerateSWOptions = workboxPluginMode === 'GenerateSW'
+    ? { cacheId: siteName }
+    : {}
+
+  const workBoxConfig = Object.assign(defaultGenerateSWOptions, options.workboxOptions)
+
+  workBoxConfig.exclude = workBoxConfig.exclude
+    ? essentialExclude.concat(workBoxConfig.exclude)
+    : essentialExclude.concat(defaultExclude)
+
+  return workBoxConfig
+}

--- a/lib/generateWorkboxConfig.js
+++ b/lib/generateWorkboxConfig.js
@@ -10,9 +10,7 @@ const defaultExclude = [
   /assets\/icons/
 ]
 
-module.exports = (siteName, options) => {
-  const workboxPluginMode = options.workboxPluginMode
-
+module.exports = (siteName, workboxPluginMode, workboxOptions) => {
   if (!workboxModes.includes(workboxPluginMode)) {
     throw new Error(
       `${workboxPluginMode} is not a supported Workbox webpack plugin mode. ` +
@@ -24,7 +22,7 @@ module.exports = (siteName, options) => {
     ? { cacheId: siteName }
     : {}
 
-  const workBoxConfig = Object.assign(defaultGenerateSWOptions, options.workboxOptions)
+  const workBoxConfig = Object.assign(defaultGenerateSWOptions, workboxOptions)
 
   workBoxConfig.exclude = workBoxConfig.exclude
     ? essentialExclude.concat(workBoxConfig.exclude)

--- a/lib/generateWorkboxConfig.js
+++ b/lib/generateWorkboxConfig.js
@@ -24,9 +24,11 @@ module.exports = (siteName, workboxPluginMode, workboxOptions) => {
 
   const workBoxConfig = Object.assign(defaultGenerateSWOptions, workboxOptions)
 
-  workBoxConfig.exclude = workBoxConfig.exclude
-    ? essentialExclude.concat(workBoxConfig.exclude)
-    : essentialExclude.concat(defaultExclude)
+  if (workboxPluginMode === 'GenerateSW') {
+    workBoxConfig.exclude = workBoxConfig.exclude
+      ? essentialExclude.concat(workBoxConfig.exclude)
+      : essentialExclude.concat(defaultExclude)
+  }
 
   return workBoxConfig
 }

--- a/lib/manifestPlugin.js
+++ b/lib/manifestPlugin.js
@@ -1,5 +1,5 @@
 const sharp = require('sharp')
-const rename = require('rename')
+const generateManifest = require('./generateManifest')
 
 const ID = 'gridsome:manifest-plugin'
 
@@ -13,53 +13,27 @@ module.exports = class ManifestPlugin {
       const logger = compiler.getInfrastructureLogger(ID)
 
       compilation.hooks.additionalAssets.tapPromise(ID, async () => {
-        const options = this.options
-        const manifestDest = options.manifestPath
-        const iconsDir = 'assets/icons/'
-        const iconName = options.icon.split('/').slice(-1)[0]
-        const type = 'image/' + iconName.split('.').slice(-1)[0]
-
-        // Generate all size images from options.icon
-        const sizes = [512, 384, 192, 180, 152, 144, 128, 120, 96, 72, 48, 16]
-
-        const icons = []
+        const manifestDest = this.options.manifestPath
+        const outputManifest = generateManifest(this.options)
+        const manifestString = JSON.stringify(outputManifest)
+        logger.info('Writing manifest to ' + manifestDest)
+        compilation.emitAsset(manifestDest, {
+          source: () => manifestString,
+          size: () => manifestString.length
+        })
         logger.info('Generating icons')
         await Promise.all(
-          sizes.map(async (size) => {
-            const sizes = `${size}x${size}`
-            const src = iconsDir + rename(iconName, { suffix: `-${sizes}` })
-            icons.push({
-              src,
-              type,
-              sizes,
-              purpose: options.maskableIcon ? 'maskable any' : 'any'
-            })
-            const imageData = await sharp(options.icon)
+          outputManifest.icons.map(async icon => {
+            const size = parseInt(icon.sizes.match(/\d+/), 10)
+            const imageData = await sharp(this.options.icon)
               .resize(size, size)
               .toBuffer()
-            compilation.emitAsset(src, {
+            compilation.emitAsset(icon.src, {
               source: () => imageData,
               size: () => imageData.length
             })
           })
         )
-        const defaultManifest = {
-          start_url: '.',
-          display: 'standalone',
-          background_color: '#000000',
-          icons,
-          name: options.name,
-          short_name: options.name,
-          theme_color: options.themeColor
-        }
-        const outputManifest = JSON.stringify(
-          Object.assign(defaultManifest, options.manifestOptions)
-        )
-        logger.info('Writing manifest to ' + manifestDest)
-        compilation.emitAsset(manifestDest, {
-          source: () => outputManifest,
-          size: () => outputManifest.length
-        })
       })
     })
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint --fix . --ext .js",
     "test": "jest",
     "test:build": "jest __tests__/basic.build.e2e.js --runInBand --detectOpenHandles",
-    "test:develop": "jest __tests__/basic.develop.e2e.js --runInBand --detectOpenHandles"
+    "test:develop": "jest __tests__/basic.develop.e2e.js --runInBand --detectOpenHandles",
+    "test:unit": "jest __tests__/*.unit.js"
   },
   "keywords": [
     "gridsome-plugin"


### PR DESCRIPTION
Closing #2

It's hard to separate the works because I need refractor to do unitest, and bugs appear when writing tests.

Main work:
- Refractor and add `generateManifest.js` and `generateWorkboxConfig.js`
- Add manifest and workbox config unit test
- Fix default workbox config, default name

Note that meta tags are still not tested, because it's not a common js module