### PR TITLE
Use workbox-build to precache non-asset files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Overview
 
-This plugin is based on [gridsome-plugin-pwa](https://github.com/rishabh3112/gridsome-plugin-pwa) and `@vue/cli-plugin-pwa`, and it is created to be a better alternative. it serves manifest and no-op service worker in development, use `workbox-webpack-plugin`, use similar config structure, just as `vue-cli` does
+This plugin is based on [gridsome-plugin-pwa](https://github.com/rishabh3112/gridsome-plugin-pwa) and `@vue/cli-plugin-pwa`, and it is created to be a better alternative. it serves manifest and no-op service worker in development, use similar config structure, just as `vue-cli` does
 
 It tries to be more similar to `cli-plugin-pwa`, but makes use of gridsome's image processing power.
 
@@ -43,40 +43,36 @@ yarn add @allanchain/gridsome-plugin-pwa register-service-worker
 - **workboxPluginMode**
 
   This allows you to the choose between the two modes supported by the underlying
-  [`workbox-webpack-plugin`](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin).
+  [`workbox-build`](https://developers.google.com/web/tools/workbox/modules/workbox-build).
 
-  - `'GenerateSW'` (default), will lead to a new service worker file being created
+  - `'generateSW'` (default), will lead to a new service worker file being created
   each time you rebuild your web app.
 
-  - `'InjectManifest'` allows you to start with an existing service worker file,
+  - `'injectManifest'` allows you to start with an existing service worker file,
   and creates a copy of that file with a "precache manifest" injected into it.
 
-  The "[Which Plugin to Use?](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#which_plugin_to_use)"
+  The "[Which Plugin to Use?](https://developers.google.com/web/tools/workbox/modules/workbox-build#which_plugin_to_use)"
   guide can help you choose between the two modes.
 
 - **workboxOptions**
   
   - Default:
-    - `{}` if `InjectManifest`
-    - if `GenerateSW`
 
-      you can override `/assets\/icons/` if provide `exclude` yourself, but cannot override first two because thay are to prevent error.
+    ```js
+    {
+      globDirectory: config.outputDir,
+      globPatterns: ['assets/@(js|css)/*'],
+      swDest: path.join(config.outputDir, 'service-worker.js')
+      sourcemap: false, // if generateSW
+      cacheId: config.siteName // if generateSW
+    }
+    ```
 
-      ```js
-      {
-        exclude: [
-          /styles(\.\w{8})?\.js$/,
-          /manifest\/client.json$/,
-          /assets\/icons/
-        ]
-      }
-      ```
-
-  These options are passed on through to the underlying `workbox-webpack-plugin`.
+  These options are passed on through to the underlying `workbox-build`.
 
   For more information on what values are supported, please see the guide for
-  [`GenerateSW`](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#full_generatesw_config)
-  or for [`InjectManifest`](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#full_injectmanifest_config).
+  [`generateSW`](https://developers.google.com/web/tools/workbox/modules/workbox-build#full_generateSW_config)
+  or for [`injectManifest`](https://developers.google.com/web/tools/workbox/modules/workbox-build#full_injectManifest_config).
 
 - **name**
 
@@ -158,7 +154,7 @@ yarn add @allanchain/gridsome-plugin-pwa register-service-worker
 
 You can also checkout [example gridsome app](examples/basic/gridsome.config.js).
 
-`GenerateSW` mode:
+`generateSW` mode:
 
 ```js
   plugins: [
@@ -181,7 +177,7 @@ You can also checkout [example gridsome app](examples/basic/gridsome.config.js).
         manifestPath: 'manifest.json',
         icon: 'src/favicon.png',
         msTileColor: '#00a672',
-        workboxOptions: { // options passed to workbox-webpack-plugin
+        workboxOptions: {
           cacheId: 'awesome-pwa',
           skipWaiting: true,
           exclude: [
@@ -193,11 +189,11 @@ You can also checkout [example gridsome app](examples/basic/gridsome.config.js).
   ]
 ```
 
-`InjectManifest` mode:
+`injectManifest` mode:
 
 ```js
 {
-  workboxPluginMode: 'InjectManifest',
+  workboxPluginMode: 'injectManifest',
   workboxOptions: {
     swSrc: './src/service-worker.js',
     additionalManifestEntries: [

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   - [1. Add to Dependencies](#1-add-to-dependencies)
   - [2. Register as Gridsome Plugin](#2-register-as-gridsome-plugin)
     - [Configuration](#configuration)
-    - [Sample Config](#sample-config)
+    - [Example Configuration](#example-configuration)
   - [3. Register service worker](#3-register-service-worker)
 - [Developing and Testing](#developing-and-testing)
 - [LICENSE](#license)
@@ -151,43 +151,34 @@ yarn add @allanchain/gridsome-plugin-pwa register-service-worker
 
   - Default: `themeColor`
 
-#### Sample Config
+#### Example Configuration
 
 You can also checkout [example gridsome app](examples/basic/gridsome.config.js).
 
 `generateSW` mode:
 
 ```js
-  plugins: [
-    {
-      use: '@allanchain/gridsome-plugin-pwa',
-      options: {
-        name: 'Awesome Gridsome',
-        manifestOptions: {
-          short_name: 'Gridsome',
-          description: 'Gridsome is awesome!',
-          display: 'standalone',
-          background_color: '#ffffff',
-          gcm_sender_id: undefined,
-          start_url: '/',
-          categories: ['education'],
-          lang: 'en-GB',
-          dir: 'auto'
-        },
-        appleMobileWebAppStatusBarStyle: 'default',
-        manifestPath: 'manifest.json',
-        icon: 'src/favicon.png',
-        msTileColor: '#00a672',
-        workboxOptions: {
-          cacheId: 'awesome-pwa',
-          skipWaiting: true,
-          exclude: [
-            /manifest\.json/
-          ]
-        }
-      }
-    }
-  ]
+{
+  manifestOptions: {
+    short_name: 'Gridsome',
+    description: 'Gridsome is awesome!',
+    display: 'standalone',
+    gcm_sender_id: undefined,
+    start_url: '/',
+    categories: ['education'],
+    lang: 'en-GB',
+    dir: 'auto'
+  },
+  appleMobileWebAppStatusBarStyle: 'default',
+  manifestPath: 'manifest.json',
+  icon: 'src/favicon.png',
+  msTileColor: '#00a672',
+  workboxOptions: {
+    cacheId: 'awesome-pwa',
+    globPatterns: ['assets/@(js|css)/*', 'index.html'],
+    skipWaiting: true
+  }
+}
 ```
 
 `injectManifest` mode:
@@ -197,9 +188,7 @@ You can also checkout [example gridsome app](examples/basic/gridsome.config.js).
   workboxPluginMode: 'injectManifest',
   workboxOptions: {
     swSrc: './src/service-worker.js',
-    additionalManifestEntries: [
-      '/index.html' // also precache '/index.html'
-    ]
+    globPatterns: ['assets/@(js|css)/*', 'index.html']
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ yarn add @allanchain/gridsome-plugin-pwa register-service-worker
 
     ```js
     {
+      modifyURLPrefix: { '': config.publicPath },
       globDirectory: config.outputDir,
       globPatterns: ['assets/@(js|css)/*'],
       swDest: path.join(config.outputDir, 'service-worker.js')

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ yarn add @allanchain/gridsome-plugin-pwa register-service-worker
   [`generateSW`](https://developers.google.com/web/tools/workbox/modules/workbox-build#full_generateSW_config)
   or for [`injectManifest`](https://developers.google.com/web/tools/workbox/modules/workbox-build#full_injectManifest_config).
 
+  **It is not recommended to precache all files**, because your site can be large. Instead, precache important files and consider runtime caching for other files.
+
 - **name**
 
   - Default: "siteName" field in gridsome config

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ yarn add @allanchain/gridsome-plugin-pwa register-service-worker
   The "[Which Plugin to Use?](https://developers.google.com/web/tools/workbox/modules/workbox-build#which_plugin_to_use)"
   guide can help you choose between the two modes.
 
+- **workboxCompileSrc**
+
+  - Default: `true`
+  
+  Only works in `injectManifest` mode. Compile your `service-worker.js` with webpack.
+
 - **workboxOptions**
   
   - Default:

--- a/__tests__/basic.build.e2e.js
+++ b/__tests__/basic.build.e2e.js
@@ -1,17 +1,9 @@
-const path = require('path')
 const fs = require('fs')
 
-const context = path.join(__dirname, '..', 'examples', 'basic')
-const dist = (...file) => path.join(context, 'gridsome', ...file)
-
-process.chdir(context)
-
-const build = require(path.join(
-  context, 'node_modules', 'gridsome', 'lib', 'build.js'
-))
+const { dist, build } = require('./utils')
 
 beforeAll(async () => {
-  await build(context)
+  await build()
 }, 60000)
 
 describe('manifest.json', () => {

--- a/__tests__/basic.build.e2e.js
+++ b/__tests__/basic.build.e2e.js
@@ -68,6 +68,7 @@ describe('sevice worker', () => {
   })
   it('includes prefetch assets', () => {
     expect(swContent).toMatch('/gridsome/assets/js/app')
+    expect(swContent).toMatch('/gridsome/index.html')
   })
   it('uses skip waiting', () => {
     expect(swContent).toMatch('skipWaiting()')

--- a/__tests__/basic.build.e2e.js
+++ b/__tests__/basic.build.e2e.js
@@ -66,9 +66,6 @@ describe('sevice worker', () => {
   it('does configured ignore', () => {
     expect(swContent).not.toMatch('manifest.json')
   })
-  it('does not ignore default if configured', () => {
-    expect(swContent).toMatch('assets/icons')
-  })
   it('includes prefetch assets', () => {
     expect(swContent).toMatch('/gridsome/assets/js/app')
   })

--- a/__tests__/inject.build.e2e.js
+++ b/__tests__/inject.build.e2e.js
@@ -1,0 +1,30 @@
+const fs = require('fs')
+
+const { dist, build } = require('./utils')
+
+beforeAll(async () => {
+  process.env.PWA_OPTIONS = 'injectManifest'
+  await build()
+}, 60000)
+
+afterAll(() => {
+  process.env.PWA_OPTIONS = ''
+})
+
+describe('sevice worker', () => {
+  const sw = dist('service-worker.js')
+  let swContent
+  it('exists', () => {
+    expect(fs.existsSync(sw)).toBeTruthy()
+    swContent = fs.readFileSync(sw, 'utf8')
+  })
+  it('has reasonable size', () => {
+    expect(fs.statSync(sw).size).toBeGreaterThan(10000)
+  })
+  it('includes original code', () => {
+    expect(swContent).toMatch('/gridsome/index.html')
+  })
+  it('injects manfest', () => {
+    expect(swContent).toMatch('')
+  })
+})

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,0 +1,14 @@
+const path = require('path')
+
+const context = path.join(__dirname, '..', 'examples', 'basic')
+process.chdir(context)
+
+const build = require(path.join(
+  context, 'node_modules', 'gridsome', 'lib', 'build.js'
+))
+
+module.exports = {
+  context,
+  dist: (...file) => path.join(context, 'gridsome', ...file),
+  build: async () => build(context)
+}

--- a/__tests__/workbox.unit.js
+++ b/__tests__/workbox.unit.js
@@ -10,11 +10,7 @@ const apiConfig = {
 
 const workbox = userOptions => {
   const options = defaultsDeep(userOptions, defaultOptions())
-  return generateWorkboxConfig(
-    apiConfig,
-    options.workboxPluginMode,
-    options.workboxOptions
-  )
+  return generateWorkboxConfig(apiConfig, options)
 }
 
 describe('Generate Workbox Config', () => {

--- a/__tests__/workbox.unit.js
+++ b/__tests__/workbox.unit.js
@@ -2,10 +2,16 @@ const generateWorkboxConfig = require('../lib/generateWorkboxConfig')
 const { defaultOptions } = require('../gridsome.server')
 const defaultsDeep = require('lodash/defaultsDeep')
 
+const apiConfig = {
+  siteName: 'Awesome Gridsome',
+  outputDir: 'gridsome',
+  publicPath: 'gridsome/'
+}
+
 const workbox = userOptions => {
   const options = defaultsDeep(userOptions, defaultOptions())
   return generateWorkboxConfig(
-    'Awesome Gridsome',
+    apiConfig,
     options.workboxPluginMode,
     options.workboxOptions
   )
@@ -13,32 +19,31 @@ const workbox = userOptions => {
 
 describe('Generate Workbox Config', () => {
   it('works with zero config', () => {
-    const config = workbox({})
-    expect(config.cacheId).toBe('Awesome Gridsome')
-    expect(config.exclude.length).toBe(3)
+    const { workboxConfig, compileOptions } = workbox({})
+    expect(workboxConfig.cacheId).toBe('Awesome Gridsome')
+    expect(workboxConfig.swDest).toBe('gridsome/service-worker.js')
+    expect(compileOptions).toBe(false)
   })
   it('throws error on unknown mode', () => {
     expect(() => workbox({ workboxPluginMode: 'InhectManidfet' }))
       .toThrow('is not a supported')
   })
   it('takes config', () => {
-    expect(workbox({ workboxOptions: { skipWaiting: true } }).skipWaiting)
-      .toBeTruthy()
+    expect(
+      workbox({ workboxOptions: { skipWaiting: true } })
+        .workboxConfig.skipWaiting
+    ).toBeTruthy()
   })
-  it('should be able to use InjectManifest', () => {
-    const config = workbox({
-      workboxPluginMode: 'InjectManifest',
+  it('should be able to use injectManifest', () => {
+    const { workboxConfig, compileOptions } = workbox({
+      workboxPluginMode: 'injectManifest',
       workboxOptions: {
-        swSrc: 'src/sw.js'
+        swSrc: './src/sw.js',
+        swDest: 'gridsome/sw.js'
       }
     })
-    expect(config).toEqual({
-      swSrc: 'src/sw.js',
-      exclude: [
-        /styles(\.\w{8})?\.js$/,
-        /manifest\/client.json$/,
-        /assets\/icons/
-      ]
-    })
+    expect(workboxConfig.swSrc).toBe('gridsome/sw.js')
+    expect(compileOptions.swSrc).toBe('./src/sw.js')
+    expect(compileOptions.swDest).toBe('sw.js')
   })
 })

--- a/examples/basic/gridsome.config.js
+++ b/examples/basic/gridsome.config.js
@@ -22,19 +22,14 @@ const options = {
     msTileColor: '#00a672',
     workboxOptions: {
       cacheId: 'awesome-pwa',
-      skipWaiting: true,
-      exclude: [
-        /manifest\.json/
-      ]
+      skipWaiting: true
     }
   },
-  InjectManifest: {
-    workboxPluginMode: 'InjectManifest',
+  injectManifest: {
+    workboxPluginMode: 'injectManifest',
     workboxOptions: {
       swSrc: './src/service-worker.js',
-      additionalManifestEntries: [
-        '/gridsome/index.html'
-      ]
+      globPatterns: ['assets/@(js|css)/*', 'index.html']
     }
   }
 }

--- a/examples/basic/gridsome.config.js
+++ b/examples/basic/gridsome.config.js
@@ -22,6 +22,7 @@ const options = {
     msTileColor: '#00a672',
     workboxOptions: {
       cacheId: 'awesome-pwa',
+      globPatterns: ['assets/@(js|css)/*', 'index.html'],
       skipWaiting: true
     }
   },

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -3,7 +3,7 @@ function Plugin (api, options) {
 
   // shared between webpack and workbox config
   let workboxConfig, compileOptions
-  console.info(options, process.env.NODE_ENV)
+
   if (process.env.NODE_ENV === 'production') {
     const generateWorkboxConfig = require('./lib/generateWorkboxConfig');
     ({ workboxConfig, compileOptions } = generateWorkboxConfig(

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -1,6 +1,18 @@
 function Plugin (api, options) {
   options = Object.assign({ name: api.config.siteName }, options)
 
+  // shared between webpack and workbox config
+  let workboxConfig, compileOptions
+
+  if (process.env.NODE_ENV === 'production') {
+    const generateWorkboxConfig = require('./lib/generateWorkboxConfig');
+    ({ workboxConfig, compileOptions } = generateWorkboxConfig(
+      api.config,
+      options.workboxPluginMode,
+      options.workboxOptions
+    ))
+  }
+
   api.chainWebpack((webpackConfig, { isServer, isProd }) => {
     if (isServer) return
 
@@ -9,21 +21,20 @@ function Plugin (api, options) {
       .plugin('pwa-manifest')
       .use(ManifestPlugin, [options])
 
-    // generate /service-worker.js in production mode
-    if (isProd) {
-      const workboxWebpackModule = require('workbox-webpack-plugin')
-      const generateWorkboxConfig = require('./lib/generateWorkboxConfig')
+    if (isProd && options.workboxPluginMode === 'injectManifest') {
+      const compileSWPlugin = require('./lib/compileSWPlugin')
       webpackConfig
-        .plugin('workbox')
-        .use(
-          workboxWebpackModule[options.workboxPluginMode],
-          [generateWorkboxConfig(
-            api.config.siteName,
-            options.workboxPluginMode,
-            options.workboxOptions
-          )]
-        )
+        .plugin('compile-sw')
+        .use(compileSWPlugin, [compileOptions])
     }
+  })
+
+  api.afterBuild(() => {
+    const workboxBuildModule = require('workbox-build')
+    workboxBuildModule[options.workboxPluginMode](workboxConfig)
+      .then(({ count, size }) => {
+        console.log(`Precache ${count} files, totaling ${size} bytes.`)
+      })
   })
 
   api.configureServer(app => {
@@ -49,7 +60,7 @@ Plugin.defaultOptions = () => ({
   icon: 'src/favicon.png',
   maskableIcon: false,
   msTileColor: '#00a672',
-  workboxPluginMode: 'GenerateSW',
+  workboxPluginMode: 'generateSW',
   workboxOptions: {}
 })
 

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -3,7 +3,7 @@ function Plugin (api, options) {
 
   // shared between webpack and workbox config
   let workboxConfig, compileOptions
-
+  console.info(options, process.env.NODE_ENV)
   if (process.env.NODE_ENV === 'production') {
     const generateWorkboxConfig = require('./lib/generateWorkboxConfig');
     ({ workboxConfig, compileOptions } = generateWorkboxConfig(
@@ -29,12 +29,11 @@ function Plugin (api, options) {
     }
   })
 
-  api.afterBuild(() => {
+  api.afterBuild(async () => {
     const workboxBuildModule = require('workbox-build')
-    workboxBuildModule[options.workboxPluginMode](workboxConfig)
-      .then(({ count, size }) => {
-        console.log(`Precache ${count} files, totaling ${size} bytes.`)
-      })
+    const workboxBuildFunc = workboxBuildModule[options.workboxPluginMode]
+    const { count, size } = await workboxBuildFunc(workboxConfig)
+    console.log(`Precache ${count} files, totaling ${size} bytes.`)
   })
 
   api.configureServer(app => {

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -8,8 +8,7 @@ function Plugin (api, options) {
     const generateWorkboxConfig = require('./lib/generateWorkboxConfig');
     ({ workboxConfig, compileOptions } = generateWorkboxConfig(
       api.config,
-      options.workboxPluginMode,
-      options.workboxOptions
+      options
     ))
   }
 
@@ -21,7 +20,7 @@ function Plugin (api, options) {
       .plugin('pwa-manifest')
       .use(ManifestPlugin, [options])
 
-    if (isProd && options.workboxPluginMode === 'injectManifest') {
+    if (isProd && compileOptions) {
       const compileSWPlugin = require('./lib/compileSWPlugin')
       webpackConfig
         .plugin('compile-sw')
@@ -60,6 +59,7 @@ Plugin.defaultOptions = () => ({
   maskableIcon: false,
   msTileColor: '#00a672',
   workboxPluginMode: 'generateSW',
+  workboxCompileSrc: true,
   workboxOptions: {}
 })
 

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -32,6 +32,7 @@ function Plugin (api, options) {
     const workboxBuildModule = require('workbox-build')
     const workboxBuildFunc = workboxBuildModule[options.workboxPluginMode]
     const { count, size } = await workboxBuildFunc(workboxConfig)
+    // eslint-disable-next-line no-console
     console.log(`Precache ${count} files, totaling ${size} bytes.`)
   })
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   verbose: true,
-  setupFilesAfterEnv: ['./jest.setup.js']
+  setupFilesAfterEnv: ['./jest.setup.js'],
+  testPathIgnorePatterns: ['utils.js']
 }

--- a/lib/compileSWPlugin.js
+++ b/lib/compileSWPlugin.js
@@ -1,5 +1,9 @@
+/**
+ * Code from https://github.com/GoogleChrome/workbox/blob/v6/packages/workbox-webpack-plugin/src/inject-manifest.js#L166-L207
+ * with MIT License
+ */
 const { SingleEntryPlugin } = require('webpack')
-const ID = 'gridsome:manifest-plugin'
+const ID = 'gridsome:compile-sw-plugin'
 
 module.exports = class CompileSWPlugin {
   constructor (config) {

--- a/lib/compileSWPlugin.js
+++ b/lib/compileSWPlugin.js
@@ -1,0 +1,57 @@
+const { SingleEntryPlugin } = require('webpack')
+const ID = 'gridsome:manifest-plugin'
+
+module.exports = class CompileSWPlugin {
+  constructor (config) {
+    this.config = config
+  }
+
+  apply (compiler) {
+    compiler.hooks.thisCompilation.tap(ID, (compilation) => {
+      compilation.hooks.additionalAssets.tapPromise(ID, async () => {
+        const logger = compiler.getInfrastructureLogger(ID)
+        logger.info(JSON.stringify(this.config))
+        const outputOptions = {
+          path: compiler.options.output.path,
+          filename: this.config.swDest
+        }
+
+        const childCompiler = compilation.createChildCompiler(
+          ID,
+          outputOptions
+        )
+
+        childCompiler.context = compiler.context
+        childCompiler.inputFileSystem = compiler.inputFileSystem
+        childCompiler.outputFileSystem = compiler.outputFileSystem
+
+        if (Array.isArray(this.config.webpackCompilationPlugins)) {
+          for (const plugin of this.config.webpackCompilationPlugins) {
+            plugin.apply(childCompiler)
+          }
+        }
+
+        new SingleEntryPlugin(
+          compiler.context,
+          this.config.swSrc,
+          ID
+        ).apply(childCompiler)
+
+        await new Promise((resolve, reject) => {
+          childCompiler.runAsChild((error, entries, childCompilation) => {
+            if (error) {
+              reject(error)
+            } else {
+              compilation.warnings = compilation.warnings.concat(
+                childCompilation.warnings)
+              compilation.errors = compilation.errors.concat(
+                childCompilation.errors)
+
+              resolve()
+            }
+          })
+        })
+      })
+    })
+  }
+}

--- a/lib/generateWorkboxConfig.js
+++ b/lib/generateWorkboxConfig.js
@@ -2,11 +2,11 @@ const path = require('path')
 
 const workboxModes = ['generateSW', 'injectManifest']
 
-module.exports = (config, workboxPluginMode, workboxOptions) => {
-  if (!workboxModes.includes(workboxPluginMode)) {
+module.exports = (config, options) => {
+  if (!workboxModes.includes(options.workboxPluginMode)) {
     throw new Error(
-      `${workboxPluginMode} is not a supported Workbox webpack plugin mode. ` +
-      `Valid modes are: ${workboxModes}`
+      `${options.workboxPluginMode} is not a supported Workbox ` +
+      `webpack plugin mode. Valid modes are: ${workboxModes}`
     )
   }
 
@@ -17,17 +17,23 @@ module.exports = (config, workboxPluginMode, workboxOptions) => {
     swDest: path.join(config.outputDir, 'service-worker.js')
   }
 
-  if (workboxPluginMode === 'generateSW') {
+  if (options.workboxPluginMode === 'generateSW') {
     Object.assign(defaultWorkboxOptions, {
       cacheId: config.siteName,
       sourcemap: false
     })
   }
 
-  const workboxConfig = Object.assign(defaultWorkboxOptions, workboxOptions)
+  const workboxConfig = Object.assign(
+    defaultWorkboxOptions,
+    options.workboxOptions
+  )
 
   let compileOptions = false
-  if (workboxPluginMode === 'injectManifest') {
+  if (
+    options.workboxPluginMode === 'injectManifest' &&
+    options.workboxCompileSrc
+  ) {
     compileOptions = {
       swSrc: workboxConfig.swSrc,
       swDest: path.relative(config.outputDir, workboxConfig.swDest)

--- a/lib/generateWorkboxConfig.js
+++ b/lib/generateWorkboxConfig.js
@@ -11,6 +11,7 @@ module.exports = (config, workboxPluginMode, workboxOptions) => {
   }
 
   const defaultWorkboxOptions = {
+    modifyURLPrefix: { '': config.publicPath },
     globDirectory: config.outputDir,
     globPatterns: ['assets/@(js|css)/*'],
     swDest: path.join(config.outputDir, 'service-worker.js')

--- a/lib/generateWorkboxConfig.js
+++ b/lib/generateWorkboxConfig.js
@@ -1,16 +1,8 @@
-const workboxModes = ['GenerateSW', 'InjectManifest']
+const path = require('path')
 
-// https://github.com/gridsome/gridsome/blob/2538985/gridsome/lib/webpack/utils.js#L5
-const essentialExclude = [
-  /styles(\.\w{8})?\.js$/,
-  /manifest\/client.json$/
-]
+const workboxModes = ['generateSW', 'injectManifest']
 
-const defaultExclude = [
-  /assets\/icons/
-]
-
-module.exports = (siteName, workboxPluginMode, workboxOptions) => {
+module.exports = (config, workboxPluginMode, workboxOptions) => {
   if (!workboxModes.includes(workboxPluginMode)) {
     throw new Error(
       `${workboxPluginMode} is not a supported Workbox webpack plugin mode. ` +
@@ -18,15 +10,33 @@ module.exports = (siteName, workboxPluginMode, workboxOptions) => {
     )
   }
 
-  const defaultGenerateSWOptions = workboxPluginMode === 'GenerateSW'
-    ? { cacheId: siteName }
-    : {}
+  const defaultWorkboxOptions = {
+    globDirectory: config.outputDir,
+    globPatterns: ['assets/@(js|css)/*'],
+    swDest: path.join(config.outputDir, 'service-worker.js')
+  }
 
-  const workBoxConfig = Object.assign(defaultGenerateSWOptions, workboxOptions)
+  if (workboxPluginMode === 'generateSW') {
+    Object.assign(defaultWorkboxOptions, {
+      cacheId: config.siteName,
+      sourcemap: false
+    })
+  }
 
-  workBoxConfig.exclude = workBoxConfig.exclude
-    ? essentialExclude.concat(workBoxConfig.exclude)
-    : essentialExclude.concat(defaultExclude)
+  const workboxConfig = Object.assign(defaultWorkboxOptions, workboxOptions)
 
-  return workBoxConfig
+  let compileOptions = false
+  if (workboxPluginMode === 'injectManifest') {
+    compileOptions = {
+      swSrc: workboxConfig.swSrc,
+      swDest: path.relative(config.outputDir, workboxConfig.swDest)
+    }
+    // inject manifest derectly into compiled sw
+    workboxConfig.swSrc = workboxConfig.swDest
+  }
+
+  return {
+    workboxConfig,
+    compileOptions
+  }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "core-js": "^3.6.5",
     "rename": "^1.0.4",
     "webpack": "^4.0.0",
-    "workbox-webpack-plugin": "^5.1.2"
+    "workbox-build": "^5.1.3"
   },
   "peerDependencies": {
     "sharp": "0.25.x"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "lint": "eslint --fix . --ext .js",
     "test": "jest",
-    "test:build": "jest __tests__/basic.build.e2e.js --runInBand --detectOpenHandles",
-    "test:develop": "jest __tests__/basic.develop.e2e.js --runInBand --detectOpenHandles",
+    "test:build": "jest __tests__/*.build.e2e.js --runInBand --detectOpenHandles",
+    "test:develop": "jest __tests__/*.develop.e2e.js --runInBand --detectOpenHandles",
     "test:unit": "jest __tests__/*.unit.js"
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,7 +778,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.8.4":
   version "7.10.4"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
   integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
@@ -6338,7 +6338,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.1.1, upath@^1.1.2, upath@^1.2.0:
+upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
@@ -6482,7 +6482,7 @@ webidl-conversions@^6.0.0:
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
-webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
+webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
@@ -6697,18 +6697,6 @@ workbox-sw@^5.1.3:
   version "5.1.3"
   resolved "https://registry.npmjs.org/workbox-sw/-/workbox-sw-5.1.3.tgz#7bffbf034f2f5b58e1734b5b86d240019a5332bb"
   integrity sha512-Syk6RhYr/8VdFwXrxo5IpVz8Og2xapHTWJhqsZRF+TbxSvlaJs8hrvVPd7edn5ZiiVdPhE9NTeOTOg1+D+FGoA==
-
-workbox-webpack-plugin@^5.1.2:
-  version "5.1.3"
-  resolved "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-5.1.3.tgz#a7070e3ea0eedb6f87e11fd916ec5d4430a6e348"
-  integrity sha512-gxSkZ9GFLrMNC/8DGNRjcMhrt8iu+MMXhH/Fpo3wo9rKaSMsI7esGq0klTH/UloP9pNvBizVydysrB52eRhI7w==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    fast-json-stable-stringify "^2.0.0"
-    source-map-url "^0.4.0"
-    upath "^1.1.2"
-    webpack-sources "^1.3.0"
-    workbox-build "^5.1.3"
 
 workbox-window@^5.1.3:
   version "5.1.3"


### PR DESCRIPTION
There are problems when using `workbox-webpack-plugin` to generate precache manifest with gridsome, because gridsome generates html and json files after bundling, which means we cannot get exact revision of these files.

Although it is not recommended to precache all files, there are needs to precache important files, such as `/index.html` (#9)

However, `workbox-build` does not compile `service-worker.js`. The PR solves this by configuring webpack with `workbox-webpack-plugin` code.

### BREAKING CHANGES

- use `generateSW` and `injectManifest` (note lower case)
- use workbox-build config